### PR TITLE
🎯 fix: General section under admin settings wasn't expanding by default after activating wePOS Pro

### DIFF
--- a/assets/src/admin/components/Settings.vue
+++ b/assets/src/admin/components/Settings.vue
@@ -182,7 +182,7 @@
 
             this.currentTab = 'wepos_general';
             if ( typeof(localStorage) != 'undefined' ) {
-                this.currentTab = localStorage.getItem("activetab") ? localStorage.getItem("activetab") : 'wepos_general';
+                this.currentTab = localStorage.getItem("activetab") && wepos.settings_sections.length > 1 ? localStorage.getItem("activetab") : 'wepos_general';
             }
 
             this.settingSections = wepos.settings_sections;


### PR DESCRIPTION
* Fixes: https://github.com/getdokan/plugin-internal-tasks/issues/396


### Before:
![Screenshot at Jun 05 15-59-09](https://github.com/weDevsOfficial/wepos-pro/assets/82957718/9a71eeef-2625-4f10-9958-2fa0e3565dff)

### After:
[Screenshot](https://tinyurl.com/24dgy2ae)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the settings panel behavior by ensuring that a previously saved tab preference is only applied when multiple settings sections are available. This change prevents an incorrect tab activation when only one section exists, enhancing the admin interface consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->