### PR TITLE
Fix: Prevent plugin activation without WooCommerce

### DIFF
--- a/wepos.php
+++ b/wepos.php
@@ -7,6 +7,7 @@ Version: 1.3.1
 Author: weDevs
 Author URI: https://wedevs.com/
 Text Domain: wepos
+Requires Plugins: woocommerce
 Domain Path: /languages
 WC requires at least: 8.5.0
 WC tested up to: 9.9.4


### PR DESCRIPTION
# Pull Request: Fix WooCommerce Dependency Check

## 📌 Title:
**Fix: Add WooCommerce dependency check to prevent activation without required plugin**

## 📝 Description

This PR introduces a safeguard to ensure that the **wePOS** plugin only activates when **WooCommerce** is installed and active.

### ✅ Key Changes:
- Checks for `WooCommerce` on plugin load.
- Prevents plugin execution if WooCommerce is not active.
- Displays a clear, dismissible admin notice to inform the user of the missing dependency.

---

## 🧪 Steps to Test the Fix:

1. Deactivate or uninstall **WooCommerce**.
2. Attempt to activate **wePOS** plugin.
3. The plugin should:
   - Display an admin notice: "WooCommerce is required to use wePOS."
   - Not initialize or load any features.

---

### Closes 

* Closes https://github.com/getdokan/wepos-pro/issues/79


## 🎯 Why This Fix is Necessary

wePOS relies on WooCommerce's core functionality. Allowing it to activate without WooCommerce results in:
- PHP errors and undefined behavior.
- Broken or inaccessible admin pages.
- Confusing experience for end users.

Adding this dependency check:
- Prevents unexpected issues.
- Improves stability.
- Ensures a smooth onboarding experience.

---

## 🔗 Related PR
Fixes:  https://github.com/getdokan/wepos-pro/pull/82

