### PR TITLE
fix: add variable products to cart from search and barcode scanner

### DIFF
--- a/src/frontend/components/ProductVariationSelector.tsx
+++ b/src/frontend/components/ProductVariationSelector.tsx
@@ -9,8 +9,14 @@ import {
   SmartSelect,
 } from '@wedevs/plugin-ui';
 import { __ } from '@wordpress/i18n';
-import { POSProduct, ProductVariation, CartItem } from '../types';
-import { firstPresentNumber, pickRegularDisplayPrice, pickSaleDisplayPrice, toFiniteNumber } from '../utils/helpers';
+import { POSProduct, CartItem } from '../types';
+import {
+  areAllVariationAttributesSelected,
+  buildVariationCartItem,
+  findMatchingVariation,
+  getVariationAttributes,
+  SelectedAttributes,
+} from '../utils/variations';
 
 interface ProductVariationSelectorProps {
   product: POSProduct;
@@ -21,10 +27,6 @@ interface ProductVariationSelectorProps {
   onOpenChange?: (open: boolean) => void;
 }
 
-interface SelectedAttributes {
-  [attributeName: string]: string;
-}
-
 export const ProductVariationSelector: React.FC<
   ProductVariationSelectorProps
 > = ({ product, onAddToCart, children, open, onOpenChange }) => {
@@ -32,25 +34,16 @@ export const ProductVariationSelector: React.FC<
     useState<SelectedAttributes>({});
 
   // Find matching variation based on selected attributes
-  const matchingVariation = useMemo(() => {
-    if (!product.variations || product.variations.length === 0) return null;
-
-    return product.variations.find((variation: ProductVariation) => {
-      return variation.attributes.every((attr) => {
-        return selectedAttributes[attr.name] === attr.option;
-      });
-    });
-  }, [product.variations, selectedAttributes]);
+  const matchingVariation = useMemo(
+    () => findMatchingVariation(product, selectedAttributes),
+    [product, selectedAttributes],
+  );
 
   // Check if all required attributes are selected
-  const isAllAttributesSelected = useMemo(() => {
-    if (!product.attributes) return false;
-
-    const requiredAttributes = product.attributes.filter(
-      (attr) => attr.variation,
-    );
-    return requiredAttributes.every((attr) => selectedAttributes[attr.name]);
-  }, [product.attributes, selectedAttributes]);
+  const isAllAttributesSelected = useMemo(
+    () => areAllVariationAttributesSelected(product, selectedAttributes),
+    [product, selectedAttributes],
+  );
 
   // Handle attribute selection
   const handleAttributeChange = useCallback(
@@ -67,37 +60,11 @@ export const ProductVariationSelector: React.FC<
   const handleAddVariation = useCallback(() => {
     if (!matchingVariation) return;
 
-    // Build variation attributes for cart display
-    const variationAttributes = Object.entries(selectedAttributes).map(
-      ([name, option]) => ({
-        id: 0, // Will be set by the system
-        name,
-        option,
-      }),
+    const cartItem: CartItem = buildVariationCartItem(
+      product,
+      matchingVariation,
+      selectedAttributes,
     );
-
-    const cartItem: CartItem = {
-      id: Date.now(), // Generate a temporary ID
-      product_id: product.id,
-      variation_id: matchingVariation.id,
-      name: product.name,
-      sku: matchingVariation.sku || product.sku || '',
-      quantity: 1,
-      regular_price: pickRegularDisplayPrice(matchingVariation),
-      sale_price: pickSaleDisplayPrice(matchingVariation),
-      raw_regular_price: toFiniteNumber(matchingVariation.regular_price),
-      raw_sale_price: toFiniteNumber(matchingVariation.sale_price),
-      on_sale: matchingVariation.on_sale,
-      type: 'variable',
-      attribute: variationAttributes,
-      editQuantity: false,
-      tax_amount: firstPresentNumber(matchingVariation.tax_amount, product.tax_amount) ?? 0,
-      manage_stock: matchingVariation.manage_stock,
-      stock_status: matchingVariation.stock_status,
-      backorders_allowed: matchingVariation.backorders_allowed,
-      stock_quantity: matchingVariation.stock_quantity ?? undefined,
-      sold_individually: product.sold_individually,
-    };
 
     onAddToCart(cartItem);
     setSelectedAttributes({});
@@ -118,8 +85,7 @@ export const ProductVariationSelector: React.FC<
               </h3>
             </div>
 
-            {product.attributes
-              ?.filter((attr) => attr.variation)
+            {getVariationAttributes(product)
               .map((attribute) => (
                 <div key={attribute.name} className="mb-4">
                   <label className="mb-2 block text-sm font-medium text-foreground">

--- a/src/frontend/components/SearchBar.tsx
+++ b/src/frontend/components/SearchBar.tsx
@@ -9,9 +9,16 @@ import {
   DialogHeader,
   DialogTitle,
   DialogFooter,
+  toast,
 } from '@wedevs/plugin-ui';
-import { POSProduct } from '../types';
+import { CartItem, POSProduct, ProductVariation } from '../types';
 import { formatPrice, pickRegularDisplayPrice, pickSaleDisplayPrice } from '../utils/helpers';
+import {
+  areAllVariationAttributesSelected,
+  buildVariationCartItem,
+  findMatchingVariation,
+  getVariationAttributes,
+} from '../utils/variations';
 import { useBarcodeSettings } from '../hooks/useBarcodeSettings';
 import { useBarcodeScanner } from '../hooks/useBarcodeScanner';
 
@@ -21,9 +28,10 @@ interface SearchBarProps {
   products: POSProduct[];
   settings: any;
   onProductAdded: (product: POSProduct) => void;
+  onCartItemAdded: (cartItem: CartItem) => void;
 }
 
-const SearchBar: React.FC<SearchBarProps> = ({ products, settings, onProductAdded }) => {
+const SearchBar: React.FC<SearchBarProps> = ({ products, settings, onProductAdded, onCartItemAdded }) => {
   const [mode, setMode] = useState<SearchMode>('product');
   const [searchInput, setSearchInput] = useState('');
   const [showResults, setShowResults] = useState(false);
@@ -71,10 +79,11 @@ const SearchBar: React.FC<SearchBarProps> = ({ products, settings, onProductAdde
     }
   }, [selectedIndex]);
 
-  // Check if all attributes are selected for variation
+  // Check if all attributes are selected for variation. Only variation attributes
+  // are rendered, so display-only attributes must not keep the button disabled.
   const attributeDisabled = useMemo(() => {
-    if (!selectedVariationProduct?.attributes) return true;
-    return Object.keys(chosenAttribute).length < selectedVariationProduct.attributes.length;
+    if (!selectedVariationProduct) return true;
+    return !areAllVariationAttributesSelected(selectedVariationProduct, chosenAttribute);
   }, [chosenAttribute, selectedVariationProduct]);
 
   // Change mode
@@ -149,24 +158,23 @@ const SearchBar: React.FC<SearchBarProps> = ({ products, settings, onProductAdde
     });
 
     if (filterProduct.length > 0) {
-      const found = filterProduct[0] as any;
+      const found = filterProduct[0] as POSProduct;
       if (found.type === 'variable') {
-        const variations = found.variations || [];
+        const variations = (found.variations || []) as ProductVariation[];
         const matchedVariation = variations.find((item: any) => item[field]?.toString() === barcode);
         if (matchedVariation) {
-          const variationProduct = {
-            ...matchedVariation,
-            parent_id: found.id,
-            type: found.type,
-            name: found.name,
-          };
-          onProductAdded(variationProduct);
+          // The scanned code identifies the variation outright, so its own
+          // attributes are the selection.
+          const selected = Object.fromEntries(
+            (matchedVariation.attributes || []).map((attribute) => [attribute.name, attribute.option]),
+          );
+          onCartItemAdded(buildVariationCartItem(found, matchedVariation, selected));
         }
       } else {
         onProductAdded(found);
       }
     }
-  }, [settings, products, onProductAdded]);
+  }, [settings, products, onProductAdded, onCartItemAdded]);
 
   // Auto-detect barcode scanner input via keypress timing
   useBarcodeScanner({
@@ -190,37 +198,24 @@ const SearchBar: React.FC<SearchBarProps> = ({ products, settings, onProductAdde
     setShowVariationModal(true);
   }, []);
 
-  // Find matching variations from chosen attributes
-  const findMatchingVariations = useCallback((variations: any[], chosen: Record<string, string>) => {
-    return variations.filter((variation: any) => {
-      const attributes = variation.attributes || [];
-      return Object.entries(chosen).every(([name, value]) => {
-        const attr = attributes.find((a: any) => a.name === name);
-        return attr && attr.option === value;
-      });
-    });
-  }, []);
-
   // Add variation product
   const addVariationProduct = useCallback(() => {
-    if (!selectedVariationProduct?.variations) return;
+    if (!selectedVariationProduct) return;
 
-    const matched = findMatchingVariations(selectedVariationProduct.variations, chosenAttribute);
-    if (matched.length > 0) {
-      const variationProduct = {
-        ...matched[0],
-        parent_id: selectedVariationProduct.id,
-        type: selectedVariationProduct.type,
-        name: selectedVariationProduct.name,
-      };
-      onProductAdded(variationProduct);
-      setShowVariationModal(false);
-      setChosenAttribute({});
-      setShowResults(false);
-      setSearchInput('');
-      inputRef.current?.focus();
+    const matched = findMatchingVariation(selectedVariationProduct, chosenAttribute);
+
+    if (!matched) {
+      toast.error(__('This variation is not available', 'wepos'));
+      return;
     }
-  }, [selectedVariationProduct, chosenAttribute, findMatchingVariations, onProductAdded]);
+
+    onCartItemAdded(buildVariationCartItem(selectedVariationProduct, matched, chosenAttribute));
+    setShowVariationModal(false);
+    setChosenAttribute({});
+    setShowResults(false);
+    setSearchInput('');
+    inputRef.current?.focus();
+  }, [selectedVariationProduct, chosenAttribute, onCartItemAdded]);
 
   // Handle keyboard navigation in results
   const handleInputKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -377,7 +372,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ products, settings, onProductAdde
           <DialogTitle>{__('Select Variations', 'wepos')}</DialogTitle>
         </DialogHeader>
         <div className="p-5">
-          {selectedVariationProduct?.attributes?.filter(attr => attr.variation)?.map((attribute) => (
+          {selectedVariationProduct && getVariationAttributes(selectedVariationProduct).map((attribute) => (
             <div key={attribute.name} className="mb-4">
               <p className="mb-2 text-sm font-bold text-foreground">{attribute.name}</p>
               <div className="flex flex-wrap gap-2">

--- a/src/frontend/pages/Home.tsx
+++ b/src/frontend/pages/Home.tsx
@@ -1506,7 +1506,7 @@ const HomePage: React.FC = () => {
               {/* Search / Filter / View Toggle Row */}
               <div className="flex flex-col gap-2 mt-3">
                 <div className="flex flex-row items-center gap-2">
-                  <SearchBar products={products} settings={settings} onProductAdded={handleAddToCart} />
+                  <SearchBar products={products} settings={settings} onProductAdded={handleAddToCart} onCartItemAdded={handleAddToCartItem} />
                   <ProductViewToggle
                       productView={productView}
                       onToggle={toggleProductView}

--- a/src/frontend/utils/variations.ts
+++ b/src/frontend/utils/variations.ts
@@ -1,0 +1,129 @@
+import { CartItem, POSProduct, ProductVariation } from '../types';
+import {
+  firstPresentNumber,
+  pickRegularDisplayPrice,
+  pickSaleDisplayPrice,
+  toFiniteNumber,
+} from './helpers';
+
+export type SelectedAttributes = Record<string, string>;
+
+/**
+ * Attributes the shopper must pick before a variation can be resolved.
+ * A variable product may also carry display-only attributes (variation: false);
+ * those are never rendered and must not count toward "all attributes selected".
+ */
+export const getVariationAttributes = (product: POSProduct) =>
+  (product.attributes || []).filter((attribute) => attribute.variation);
+
+/**
+ * True once every variation attribute has a chosen option.
+ */
+export const areAllVariationAttributesSelected = (
+  product: POSProduct,
+  selected: SelectedAttributes,
+): boolean => {
+  const required = getVariationAttributes(product);
+
+  if (required.length === 0) return false;
+
+  return required.every((attribute) => !!selected[attribute.name]);
+};
+
+/**
+ * Resolve the variation matching the chosen attributes.
+ *
+ * Walk the *variation's* attributes, not the chosen ones: WooCommerce omits (or
+ * sends an empty option for) attributes set to "Any", so a variation legitimately
+ * carries fewer attributes than the parent declares. Requiring every chosen
+ * attribute to exist on the variation never matches those products.
+ *
+ * Exact matches win over "Any" wildcards, mirroring WC_Data_Store_WP::find_matching_product_variation.
+ */
+export const findMatchingVariation = (
+  product: POSProduct,
+  selected: SelectedAttributes,
+): ProductVariation | null => {
+  const variations = (product.variations || []) as ProductVariation[];
+
+  if (variations.length === 0) return null;
+
+  const candidates = variations.filter((variation) =>
+    (variation.attributes || []).every(
+      // Empty option means "Any" — matches whatever the shopper chose.
+      (attribute) => !attribute.option || selected[attribute.name] === attribute.option,
+    ),
+  );
+
+  if (candidates.length === 0) return null;
+
+  const specificity = (variation: ProductVariation) =>
+    (variation.attributes || []).filter((attribute) => !!attribute.option).length;
+
+  return candidates.reduce((best, variation) =>
+    specificity(variation) > specificity(best) ? variation : best,
+  );
+};
+
+/**
+ * Build the cart line for a resolved variation.
+ *
+ * Variations must go through this and never through the simple-product path:
+ * the line needs product_id = parent and variation_id = variation, otherwise the
+ * order sync can't match its own lines and the cart row loses its attribute labels.
+ */
+export const buildVariationCartItem = (
+  product: POSProduct,
+  variation: ProductVariation,
+  selected: SelectedAttributes,
+): CartItem => {
+  // Label the cart row with what the variation constrains, falling back to the
+  // cashier's pick for "Any" attributes. Barcode lookups pass no separate
+  // selection, so they end up with the variation's own attributes.
+  const constrained = new Map(
+    (variation.attributes || [])
+      .filter((attribute) => !!attribute.option)
+      .map((attribute) => [attribute.name, { id: attribute.id ?? 0, option: attribute.option }]),
+  );
+
+  const names: string[] = [];
+  const pushName = (name: string) => {
+    if (!names.includes(name)) names.push(name);
+  };
+
+  // Parent order first so the row reads the same as the variation picker.
+  getVariationAttributes(product).forEach((attribute) => pushName(attribute.name));
+  (variation.attributes || []).forEach((attribute) => pushName(attribute.name));
+  Object.keys(selected).forEach(pushName);
+
+  const variationAttributes = names
+    .map((name) => ({
+      id: constrained.get(name)?.id ?? 0,
+      name,
+      option: constrained.get(name)?.option || selected[name] || '',
+    }))
+    .filter((attribute) => !!attribute.option);
+
+  return {
+    id: Date.now(),
+    product_id: product.id,
+    variation_id: variation.id,
+    name: product.name,
+    sku: variation.sku || product.sku || '',
+    quantity: 1,
+    regular_price: pickRegularDisplayPrice(variation),
+    sale_price: pickSaleDisplayPrice(variation),
+    raw_regular_price: toFiniteNumber(variation.regular_price),
+    raw_sale_price: toFiniteNumber(variation.sale_price),
+    on_sale: variation.on_sale,
+    type: 'variable',
+    attribute: variationAttributes,
+    editQuantity: false,
+    tax_amount: firstPresentNumber(variation.tax_amount, product.tax_amount) ?? 0,
+    manage_stock: variation.manage_stock,
+    stock_status: variation.stock_status,
+    backorders_allowed: variation.backorders_allowed,
+    stock_quantity: variation.stock_quantity ?? undefined,
+    sold_individually: product.sold_individually,
+  };
+};


### PR DESCRIPTION
- Closes getdokan/wepos-pro#142

## Problem

Variable products could not be added to the cart through the **search field** or the **barcode scanner**. Picking a variation from the search dropdown did nothing at all — no cart line, no error. The same product added fine from the product grid, which is what made the report look product-specific rather than code-path-specific.

All three defects were in `SearchBar.tsx`, which carried its own copy of the variation logic that `ProductVariationSelector` (the grid path) already had.

### 1. Attribute matching never handled "Any" (the silent failure)

`findMatchingVariations` walked the **chosen** attributes and required each one to be present on the variation:

```js
Object.entries(chosen).every(([name, value]) => {
  const attr = attributes.find(a => a.name === name);
  return attr && attr.option === value;   // undefined when the variation says "Any"
});
```

WooCommerce omits attributes set to *Any* from the variation payload, so a variation legitimately carries fewer attributes than its parent declares. Any such product returned zero matches, and `addVariationProduct` returned early with no feedback.

The grid's selector walks the **variation's** attributes instead — which is exactly why the grid worked.

Verified against WC sample data (product #70 "V-Neck T-Shirt": declares Color + Size as variation attributes, every variation carries Color only, Size = Any):

```
SearchBar matches: 0 => addVariationProduct returns early, nothing added
Grid match: variation #84 added
```

### 2. Variations were sent through the simple-product handler

`Home.tsx` wired `onProductAdded={handleAddToCart}` and `SearchBar` fed it a raw variation object, so the cart line came out as:

- `product_id` = **variation** ID
- `variation_id: 0`
- `attribute: []` → no `Color: Red` label on the cart row

WooCommerce repairs the IDs server-side (`WC_Order_Item_Product::set_product` swaps in parent + variation), so the *order* was fine — but the client's own line matching then compared `sl.product_id === item.product_id && sl.variation_id === 0` against the server's corrected values, never matched, and deleted + recreated the line on every cart sync. Adding the same variation once from the grid and once by scan also produced two separate cart lines.

This hit both the barcode flow and any search-added variation that did resolve (single-attribute products such as Sunglasses #77).

### 3. "Add Product" could be permanently disabled

`attributeDisabled` compared against `attributes.length` (all attributes) while the modal rendered only `attributes.filter(a => a.variation)`. A product with any display-only attribute could never enable the button.

## Fix

New `src/frontend/utils/variations.ts` becomes the single source for variation resolution and cart-line building; `SearchBar` and `ProductVariationSelector` both use it, so the two paths can't drift again.

- `findMatchingVariation` walks the variation's attributes, treats an empty option as an *Any* wildcard, and prefers exact matches over wildcards — mirroring `WC_Data_Store_WP::find_matching_product_variation`.
- `areAllVariationAttributesSelected` counts only `variation: true` attributes.
- `buildVariationCartItem` always emits `product_id` = parent, `variation_id` = variation, and labels the row with the variation's constrained options plus the cashier's picks for *Any* attributes.
- Search and scan now go through `handleAddToCartItem` (the cart-item handler), which also gives them the stock / `sold_individually` checks the grid path already had.
- An unresolvable combination now surfaces a toast instead of failing silently.

## Verification

The real util was exercised against live REST payloads pulled from a local WooCommerce install:

| Case | Before | After |
| --- | --- | --- |
| Search, multi-attribute product with `Size = Any` | 0 matches → nothing added | variation `#84` added |
| Cart line IDs | `product_id=84, variation_id=0` | `product_id=70, variation_id=84` |
| Attribute labels (barcode) | `[]` | `Color: Blue` |
| Attribute labels (search) | `[]` | `Color: Red, Size: Large` |
| Exact match vs `Any` wildcard | n/a | exact variation wins |
| Unavailable combination | silent no-op | toast: *This variation is not available* |
| Barcode scan | wrong IDs, no labels | `70/86`, `Color: Blue` |

- `tsc --noEmit`: no new errors — the only diff vs. the `develop` baseline is one pre-existing error whose line number shifted.
- `npm run build`: compiles clean.

## Test plan

1. Variable product with a multi-attribute setup where one attribute is *Any* (e.g. WC sample "V-Neck T-Shirt"). Search it, pick a variation, add → lands in the cart with the right variation and attribute labels.
2. Same product from the product grid → unchanged behaviour.
3. Scan / submit a variation SKU (or the custom barcode field) in **Scan** mode → correct line, correct labels.
4. Add the same variation from the grid and by scan → they merge into one line, quantity 2.
5. Change quantity, then complete the order → the line syncs in place instead of being deleted and recreated; order shows parent product + variation.
6. Variable product carrying a display-only (non-variation) attribute → **Add Product** enables once the variation attributes are picked.
7. Pick a combination with no matching variation → toast, no cart line.

## Note

The issue lives in `getdokan/wepos-pro` while the buggy code is in this repo (Pro has no `SearchBar` override). GitHub's closing keywords don't work across repositories, so **wepos-pro#142 will need to be closed by hand** once this ships.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved product variation selection with more reliable matching of shopper-selected attributes.
  * Added support for adding selected product variations directly to the cart, including barcode-based additions.
  * Variation selections now display clearer availability and pricing information.
  * Improved handling of products with flexible or unspecified variation options.

* **Bug Fixes**
  * Prevented invalid variation selections from being added to the cart.
  * Improved cart item details, pricing, tax, stock, and variation information for selected products.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->